### PR TITLE
Patch to correct conflicting class name with PHP 5.3 Locale  It prevents...

### DIFF
--- a/app/Plugin/Locale/Controller/LanguagesController.php
+++ b/app/Plugin/Locale/Controller/LanguagesController.php
@@ -146,8 +146,8 @@ class LanguagesController extends LocaleAppController {
     }
 
     private function __setLangs() {
-        App::import('Lib', 'Locale.Locale');
-        $this->set('languages', Locale::languages());
-        Locale::language_direction('eng');
+        App::import('Lib', 'Locale.QALocale');
+        $this->set('languages', QALocale::languages());
+        QALocale::language_direction('eng');
     }
 }

--- a/app/Plugin/Locale/Lib/QALocale.php
+++ b/app/Plugin/Locale/Lib/QALocale.php
@@ -3,7 +3,7 @@ if (!class_exists('L10n')) {
     App::import('I18n', 'L10n');
 }
 
-class Locale {
+class QALocale extends Locale{
     static function languages() {
         $L10n = new L10n;
         $catalog = $L10n->catalog();
@@ -103,7 +103,7 @@ class Locale {
         self::format_date_callback(NULL, $langcode);
 
         // Translate the marked sequences.
-        return preg_replace_callback('/\xEF([AaeDlMTF]?)(.*?)\xFF/', array('Locale', 'format_date_callback') , $format);
+        return preg_replace_callback('/\xEF([AaeDlMTF]?)(.*?)\xFF/', array('QALocale', 'format_date_callback') , $format);
     }
 
 /**

--- a/app/Plugin/Locale/Model/Language.php
+++ b/app/Plugin/Locale/Model/Language.php
@@ -27,8 +27,8 @@ class Language extends LocaleAppModel {
     public function beforeValidate() {
         if (!isset($this->data['Language']['id']) && !isset($this->data['Language']['addCustom'])) { # new language -> determinate name&native
             if (isset($this->data['Language']['code'])) {
-                App::import('Lib', 'Locale.Locale');
-                $l = Locale::languages();
+                App::import('Lib', 'Locale.QALocale');
+                $l = QALocale::languages();
 
                 if (!isset($this->data['Language']['name'])) {
                     $this->data['Language']['name'] = @$l[$this->data['Language']['code']];
@@ -39,7 +39,7 @@ class Language extends LocaleAppModel {
                 }
 
                 if (!isset($this->data['Language']['direction'])) {
-                    $this->data['Language']['direction'] = Locale::language_direction();
+                    $this->data['Language']['direction'] = QALocale::language_direction();
                 }
             }
         }

--- a/app/Plugin/System/View/Configuration/admin_index.ctp
+++ b/app/Plugin/System/View/Configuration/admin_index.ctp
@@ -30,10 +30,10 @@
     <?php echo $this->Html->useTag('fieldsetend'); ?>
 
     <?php echo $this->Html->useTag('fieldsetstart', __t('Regional settings')); ?>
-        <?php App::import('Lib', 'Locale.Locale'); ?>
+        <?php App::import('Lib', 'Locale.QALocale'); ?>
         <?php echo $this->Form->input('Variable.default_language', array('type' => 'select', 'options' => $languages, 'label' => __t('Default language'))); ?>
 
-        <?php echo $this->Form->input('Variable.date_default_timezone', array('type' => 'select', 'options' => Locale::time_zones(), 'label' => __t('Default time zone'))); ?>
+        <?php echo $this->Form->input('Variable.date_default_timezone', array('type' => 'select', 'options' => QALocale::time_zones(), 'label' => __t('Default time zone'))); ?>
 
         <?php echo $this->Form->input('Variable.url_language_prefix', array('type' => 'checkbox', 'options' => array(0 => __t('No'), 1 => __t('Yes')), 'label' => __t('URL path prefix'))); ?>
         <em><?php echo __t('URLs like http://domain.com/fre/about set language to French (fre). <b>Warning: Changing this setting may break incoming URLs. Use with caution on a production site.</b>'); ?></em>

--- a/app/Plugin/User/View/List/admin_add.ctp
+++ b/app/Plugin/User/View/List/admin_add.ctp
@@ -12,8 +12,8 @@
         <?php echo $this->Form->input('email', array('required' => 'required', 'type' => 'email', 'label' => __t('E-mail *'))); ?>
         <?php echo $this->Form->input('public_email', array('type' => 'checkbox', 'label' => __t('Public email'))); ?>
         <?php echo $this->Form->input('language', array('type' => 'select', 'options' => $languages, 'label' => __t('Language'))); ?>
-        <?php App::import('Lib', 'Locale.Locale'); ?>
-        <?php echo $this->Form->input('timezone', array('type' => 'select', 'options' => Locale::time_zones(), 'label' => __t('Time zone'))); ?>
+        <?php App::import('Lib', 'Locale.QALocale'); ?>
+        <?php echo $this->Form->input('timezone', array('type' => 'select', 'options' => QALocale::time_zones(), 'label' => __t('Time zone'))); ?>
         <?php echo $this->Form->input('password', array('type' => 'password', 'label' => __t('Password'), 'value' => '')); ?>
         <?php echo $this->Form->input('password2', array('type' => 'password', 'label' => __t('Confirm password'))); ?>
         <?php echo $this->Form->input('Role.Role', array('type' => 'select', 'multiple' => 'checkbox', 'label' => __t('User roles'), 'options' => $roles)); ?>

--- a/app/Plugin/User/View/List/admin_edit.ctp
+++ b/app/Plugin/User/View/List/admin_edit.ctp
@@ -13,8 +13,8 @@
         <?php echo $this->Form->input('email', array('required' => 'required', 'type' => 'email', 'label' => __t('E-mail *'))); ?>
         <?php echo $this->Form->input('public_email', array('type' => 'checkbox', 'label' => __t('Public email'))); ?>
         <?php echo $this->Form->input('language', array('type' => 'select', 'options' => $languages, 'label' => __t('Language'))); ?>
-        <?php App::import('Lib', 'Locale.Locale'); ?>
-        <?php echo $this->Form->input('timezone', array('type' => 'select', 'options' => Locale::time_zones(), 'label' => __t('Time zone'))); ?>
+        <?php App::import('Lib', 'Locale.QALocale'); ?>
+        <?php echo $this->Form->input('timezone', array('type' => 'select', 'options' => QALocale::time_zones(), 'label' => __t('Time zone'))); ?>
         <?php echo $this->Form->input('password', array('type' => 'password', 'label' => __t('New password'), 'value' => '')); ?>
         <?php echo $this->Form->input('password2', array('type' => 'password', 'label' => __t('Confirm password'))); ?>
         <em><?php echo __t('If you would like to change the password type a new one. Otherwise leave this blank.'); ?></em>

--- a/app/Plugin/User/View/User/my_account.ctp
+++ b/app/Plugin/User/View/User/my_account.ctp
@@ -10,8 +10,8 @@
         <?php echo $this->Form->input('email', array('required' => 'required', 'type' => 'email', 'label' => __t('E-mail *'))); ?>
         <?php echo $this->Form->input('public_email', array('type' => 'checkbox', 'label' => __t('Public email'))); ?>
         <?php echo $this->Form->input('language', array('type' => 'select', 'options' => $languages, 'label' => __t('Language'))); ?>
-        <?php App::import('Lib', 'Locale.Locale'); ?>
-        <?php echo $this->Form->input('timezone', array('type' => 'select', 'options' => Locale::time_zones(), 'label' => __t('Time zone'))); ?>
+        <?php App::import('Lib', 'Locale.QALocale'); ?>
+        <?php echo $this->Form->input('timezone', array('type' => 'select', 'options' => QALocale::time_zones(), 'label' => __t('Time zone'))); ?>
         <?php echo $this->Form->input('password', array('type' => 'password', 'label' => __t('New password'), 'value' => '')); ?>
         <?php echo $this->Form->input('password2', array('type' => 'password', 'label' => __t('Confirm password'))); ?>
         <em><?php echo __t('If you would like to change the password type a new one. Otherwise leave this blank.'); ?></em>

--- a/app/Plugin/User/View/User/register.ctp
+++ b/app/Plugin/User/View/User/register.ctp
@@ -9,8 +9,8 @@
         <em><?php echo __t('Full url to avatar image file. i.e: http://www.some-domain.com/my-avatar.jpg'); ?></em>
         <?php echo $this->Form->input('email', array('required' => true, 'type' => 'text', 'label' => __t('E-mail *'))); ?>
         <?php echo $this->Form->input('language', array('type' => 'select', 'options' => $languages, 'label' => __t('Language'))); ?>
-        <?php App::import('Lib', 'Locale.Locale'); ?>
-        <?php echo $this->Form->input('timezone', array('type' => 'select', 'value' => Configure::read('Variable.date_default_timezone'), 'options' => Locale::time_zones(), 'label' => __t('Time zone'))); ?>
+        <?php App::import('Lib', 'Locale.QALocale'); ?>
+        <?php echo $this->Form->input('timezone', array('type' => 'select', 'value' => Configure::read('Variable.date_default_timezone'), 'options' => QALocale::time_zones(), 'label' => __t('Time zone'))); ?>
         <?php echo $this->Form->input('password', array('required' => true, 'type' => 'password', 'label' => __t('Password') . ' *', 'value' => '')); ?>
         <?php echo $this->Form->input('password2', array('required' => true, 'type' => 'password', 'label' => __t('Confirm password') . ' *')); ?>
 


### PR DESCRIPTION
... QuickCMS Locale from Loading  As discussed in 
https://github.com/QuickAppsCMS/QuickApps-CMS/issues/2#issuecomment-3441821

This patch renames the app/Plugin/Locale/Lib/Locale.php to app/Plugin/Locale/Lib/QALocale.php and changes the internal class name as well as all references in the application  It doesn't extend the PHP 5.3 Locale as it's not needed or available in php >5.3
