### PR TITLE
Fix: user account validation issues

### DIFF
--- a/QuickApps/Controller/InstallController.php
+++ b/QuickApps/Controller/InstallController.php
@@ -293,8 +293,8 @@ class InstallController extends Controller {
 			} else {
 				$errors = '';
 
-				foreach ($this->User->invalidFields() as $field => $error) {
-					$errors .= "<b>{$field}:</b> {$error}<br/>";
+				foreach ($this->User->validationErrors as $field => $error) {
+					$errors .= "<b>{$field}:</b> {$error[0]}<br/>";
 				}
 
 				$this->Session->setFlash(


### PR DESCRIPTION
Validation was occurring twice and the error messages were not being displayed correctly.
