### PR TITLE
Allow underscores to be used in attribute names

### DIFF
--- a/plugins/Eav/src/Model/Table/EavAttributesTable.php
+++ b/plugins/Eav/src/Model/Table/EavAttributesTable.php
@@ -66,9 +66,9 @@ class EavAttributesTable extends Table
                 ],
                 'regExp' => [
                     'rule' => function ($value, $context) {
-                        return preg_match('/^[a-z\d\-]+$/', $value) > 0;
+                        return preg_match('/^[a-z\d\-_]+$/', $value) > 0;
                     },
-                    'message' => __d('eav', 'Only lowercase letters, numbers and "-" symbol are allowed.'),
+                    'message' => __d('eav', 'Only lowercase letters, numbers, "-" and "_" are allowed.'),
                 ],
                 'unique' => [
                     'rule' => ['validateUnique', ['scope' => 'table_alias']],


### PR DESCRIPTION
Underscores are mostly used in table column names. Allowing underscores in attributes would make sense to be consistent with other entity properties.
