### PR TITLE
simple unary expressions support

### DIFF
--- a/plugins/Eav/src/Model/Behavior/EavToolbox.php
+++ b/plugins/Eav/src/Model/Behavior/EavToolbox.php
@@ -190,6 +190,24 @@ class EavToolbox
     }
 
     /**
+     * Gets a list of attribute IDs.
+     *
+     * @param string $bundle Filter by bundle name
+     * @return array
+     */
+    public function getAttributeIds($bundle = null)
+    {
+        $attributes = $this->attributes($bundle);
+        $ids = [];
+
+        foreach ($attributes as $name => $info) {
+            $ids[] = $info['id'];
+        }
+
+        return $ids;
+    }
+
+    /**
      * Calculates entity's primary key.
      *
      * If PK is composed of multiple columns they will be merged with `:` symbol.

--- a/plugins/Eav/src/Model/Behavior/QueryScope/WhereScope.php
+++ b/plugins/Eav/src/Model/Behavior/QueryScope/WhereScope.php
@@ -165,6 +165,14 @@ class WhereScope implements QueryScopeInterface
         return $expression;
     }
 
+    /**
+     * Analyzes the given unary expression and alters it according.
+     *
+     * @param \Cake\Database\Expression\UnaryExpression $expression Unary expression
+     * @param string $bundle Consider attributes only for a specific bundle
+     * @param \Cake\ORM\Query $query The query instance this expression comes from
+     * @return \Cake\Database\Expression\UnaryExpression Scoped expression (or not)
+     */
     protected function _inspectUnaryExpression(UnaryExpression $expression, $bundle, Query $query)
     {
         $class = new \ReflectionClass($expression);

--- a/plugins/Eav/tests/Fixture/DummyFixture.php
+++ b/plugins/Eav/tests/Fixture/DummyFixture.php
@@ -62,4 +62,15 @@ class DummyFixture extends TestFixture
             'fixed' => null,
         ],
     ];
+
+    /**
+     * Table records.
+     *
+     * @var array
+     */
+    public $records = [
+        ['id' => 1, 'name' => 'Lorem'],
+        ['id' => 2, 'name' => 'Ipsum'],
+        ['id' => 3, 'name' => 'dolor'],
+    ];
 }

--- a/plugins/Eav/tests/TestCase/Model/Behavior/EavBehaviorTest.php
+++ b/plugins/Eav/tests/TestCase/Model/Behavior/EavBehaviorTest.php
@@ -86,11 +86,17 @@ class EavBehaviorTest extends TestCase
     public function testUnaryExpression()
     {
         $this->table->addColumn('user-birth-date', ['type' => 'date'], false);
-        $count = $this->table
-            ->find()
-            ->where(['user-birth-date IS' => null])
-            ->count();
 
-        $this->assertTrue($count > 0);
+        $first = $this->table->get(1);
+        $first->set('user-birth-date', time());
+        $this->table->save($first);
+
+        $second = $this->table
+            ->find('all', ['eav' => true])
+            ->where(['user-birth-date IS' => null])
+            ->order(['id' => 'ASC'])
+            ->first();
+
+        $this->assertTrue(!empty($second) && $second->get('id') == 2);
     }
 }

--- a/plugins/Eav/tests/TestCase/Model/Behavior/EavBehaviorTest.php
+++ b/plugins/Eav/tests/TestCase/Model/Behavior/EavBehaviorTest.php
@@ -24,11 +24,11 @@ class EavBehaviorTest extends TestCase
 {
 
     /**
-     * Instance of behavior being tested.
+     * The table to which `EavBehavior` is attached to
      *
-     * @var \Eav\Model\Behavior\EavBehavior
+     * @var \Cake\ORM\Table
      */
-    public $behavior;
+    public $table;
 
     /**
      * Fixtures.
@@ -48,8 +48,8 @@ class EavBehaviorTest extends TestCase
      */
     public function setUp()
     {
-        $table = TableRegistry::get('Dummy');
-        $this->behavior = new EavBehavior($table);
+        $this->table = TableRegistry::get('Dummy');
+        $this->table->addBehavior('Eav.Eav');
     }
 
     /**
@@ -59,8 +59,8 @@ class EavBehaviorTest extends TestCase
      */
     public function testAddColumn()
     {
-        $success1 = $this->behavior->addColumn('user-age', ['type' => 'integer'], false);
-        $success2 = $this->behavior->addColumn('user-birth-date', ['type' => 'date'], false);
+        $success1 = $this->table->addColumn('user-age', ['type' => 'integer'], false);
+        $success2 = $this->table->addColumn('user-birth-date', ['type' => 'date'], false);
 
         $this->assertTrue($success1);
         $this->assertTrue($success2);
@@ -75,6 +75,22 @@ class EavBehaviorTest extends TestCase
      */
     public function testAddColumnThrows()
     {
-        $this->behavior->addColumn('name', ['type' => 'string']);
+        $this->table->addColumn('name', ['type' => 'string']);
+    }
+
+    /**
+     * test WHERE conditions against unary expression.
+     *
+     * @return void
+     */
+    public function testUnaryExpression()
+    {
+        $this->table->addColumn('user-birth-date', ['type' => 'date'], false);
+        $count = $this->table
+            ->find()
+            ->where(['user-birth-date IS' => null])
+            ->count();
+
+        $this->assertTrue($count > 0);
     }
 }


### PR DESCRIPTION
now is possible to apply simple `IS [NOT] NULL` constraints over virtual columns
