### PR TITLE
fix goaop & cakephp cache issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     },
     "require": {
         "php": ">=5.6",
-        "goaop/framework": "^2.0",
-        "cakephp/cakephp": "3.3.11",
+        "goaop/framework": "2.1.2",
+        "cakephp/cakephp": "3.3.16",
         "phpunit/phpunit": "<6.0",
         "cakephp/cakephp-codesniffer": "~2.1"
     },

--- a/plugins/CMS/composer.json
+++ b/plugins/CMS/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "goaop/framework": "^2.0"
+        "goaop/framework": "2.1.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Upgrade CakePHP core to v3.3.16, solves "record not found" & query-cache issues. (closes #182)
- Downgrade GoAOP framework to latest stable/compatible with QACMS (v2.1.2). (closes #185 )